### PR TITLE
Fix default comment width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -14,9 +14,9 @@ body .blob-code {
 	tab-size: 4;
 }
 
-body .inline-comments .comment-holder, 
-body .inline-comments .inline-comment-form, 
-body .inline-comments .inline-comment-form-container {
+body.wide-mode-activated .inline-comments .comment-holder, 
+body.wide-mode-activated .inline-comments .inline-comment-form, 
+body.wide-mode-activated .inline-comments .inline-comment-form-container {
 	max-width: 100%;
 }
 


### PR DESCRIPTION
Previously editable comments had a width
that would cut them off if the code was really long.
This change updates it so the width of the comments
is the same until the user goes into wide-mode.
